### PR TITLE
Handle blank watermark download placeholders

### DIFF
--- a/tests/test_watermark_expansion.py
+++ b/tests/test_watermark_expansion.py
@@ -1,0 +1,36 @@
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from crawler.crawler import _expand_watermark_downloads
+
+
+BASE_URL = "https://example.com/base/"
+
+
+def _collect(argument: str, templates):
+    return list(
+        _expand_watermark_downloads(argument, set(templates), BASE_URL)
+    )
+
+
+def test_blank_query_parameter_is_populated():
+    results = _collect("files/sample.pdf", {"download.php?download="})
+
+    assert (
+        "https://example.com/base/download.php?download=files%2Fsample.pdf" in results
+    )
+    assert all("show=" not in url for url in results if "download.php" in url)
+
+
+def test_falls_back_to_show_parameter_when_needed():
+    results = _collect("files/sample.pdf", {"download.php"})
+
+    assert "https://example.com/base/download.php?show=files/sample.pdf" in results
+
+
+def test_path_placeholder_is_replaced():
+    results = _collect("files/sample.pdf", {"download.php?doc={path}"})
+
+    assert "https://example.com/base/download.php?doc=files/sample.pdf" in results


### PR DESCRIPTION
## Summary
- populate blank query parameters in watermark download templates before falling back to `show=`
- clean up download helper syntax left from a conflict marker
- add regression tests covering blank placeholders, fallback, and `{path}` substitution

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68db79f95830832bb552aec1fea979b1

## Summary by Sourcery

Improve watermark download URL expansion by handling blank query placeholders before falling back to ‘show=’, clean up download helper syntax, and add regression tests for these cases.

New Features:
- Populate blank query parameters in watermark download templates before falling back to ‘show=’.

Bug Fixes:
- Ensure fallback to ‘show=’ query parameter when no blank placeholders are present.

Enhancements:
- Remove leftover conflict marker syntax and reuse parsed parameters in the PDF download helper.

Tests:
- Add regression tests for blank placeholder substitution, show= fallback, and {path} replacement.