### PR TITLE
Fix double encoding in watermark URL expansion

### DIFF
--- a/tests/test_watermark_expansion.py
+++ b/tests/test_watermark_expansion.py
@@ -34,3 +34,18 @@ def test_path_placeholder_is_replaced():
     results = _collect("files/sample.pdf", {"download.php?doc={path}"})
 
     assert "https://example.com/base/download.php?doc=files/sample.pdf" in results
+
+
+def test_space_in_filename_is_not_double_encoded():
+    results = _collect(
+        "files/My File.pdf",
+        {"download.php?download=", "download.php?show=existing"},
+    )
+
+    assert (
+        "https://example.com/base/download.php?download=files%2FMy%20File.pdf"
+        in results
+    )
+    assert (
+        "https://example.com/base/download.php?show=files%2FMy%20File.pdf" in results
+    )


### PR DESCRIPTION
## Summary
- add a shared query encoding helper so watermark download expansions only encode paths once
- update watermark expansion logic to use the helper for blank query parameters and existing show= rewrites
- extend the tests to cover filenames with spaces to prevent double encoding regressions

## Testing
- pytest tests/test_watermark_expansion.py

------
https://chatgpt.com/codex/tasks/task_e_68dba35063dc832b99329ed61b7da661

## Summary by Sourcery

Prevent double encoding in watermark download URLs by centralizing query parameter encoding and updating the expansion logic accordingly, and add tests for filenames with spaces

Bug Fixes:
- Fix double URL encoding in watermark download expansion

Enhancements:
- Introduce a shared _encode_query_parameters helper to control safe characters
- Refactor watermark expansion logic to use the shared helper for blank query parameters and show parameters

Tests:
- Add a test to verify filenames with spaces are encoded only once